### PR TITLE
feat(KFLUXVNGD-723): Add OpenShift version to public info

### DIFF
--- a/operator/internal/controller/buildservice/konfluxbuildservice_controller_test.go
+++ b/operator/internal/controller/buildservice/konfluxbuildservice_controller_test.go
@@ -136,13 +136,13 @@ var _ = Describe("KonfluxBuildService Controller", func() {
 					},
 				},
 				serverVersion: &version.Info{GitVersion: "v1.29.0"},
-			})
+			}, nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			defaultClusterInfo, err = clusterinfo.DetectWithClient(&buildServiceMockDiscoveryClient{
 				resources:     map[string]*metav1.APIResourceList{},
 				serverVersion: &version.Info{GitVersion: "v1.29.0"},
-			})
+			}, nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("creating the KonfluxBuildService resource")

--- a/operator/internal/controller/info/poller_test.go
+++ b/operator/internal/controller/info/poller_test.go
@@ -34,7 +34,7 @@ func TestVersionPoller_FiresEventOnVersionChange(t *testing.T) {
 	mockDiscovery := &MockDiscoveryClient{}
 	mockDiscovery.SetVersion("v1.29.0")
 
-	clusterInfo, err := clusterinfo.DetectWithClient(mockDiscovery)
+	clusterInfo, err := clusterinfo.DetectWithClient(mockDiscovery, nil)
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 	g.Expect(clusterInfo).NotTo(gomega.BeNil())
 

--- a/operator/internal/controller/konflux/konflux_controller_certmanager_test.go
+++ b/operator/internal/controller/konflux/konflux_controller_certmanager_test.go
@@ -64,7 +64,7 @@ var _ = Describe("Konflux Controller - Cert-Manager Dependency", func() {
 			mockDiscoveryClient := &certManagerMockDiscoveryClient{
 				hasCertManager: false,
 			}
-			clusterInfo, _ := clusterinfo.DetectWithClient(mockDiscoveryClient)
+			clusterInfo, _ := clusterinfo.DetectWithClient(mockDiscoveryClient, nil)
 
 			reconciler = &KonfluxReconciler{
 				Client:      fakeClient,
@@ -142,7 +142,7 @@ var _ = Describe("Konflux Controller - Cert-Manager Dependency", func() {
 			mockDiscoveryClient := &certManagerMockDiscoveryClient{
 				hasCertManager: true,
 			}
-			clusterInfo, _ := clusterinfo.DetectWithClient(mockDiscoveryClient)
+			clusterInfo, _ := clusterinfo.DetectWithClient(mockDiscoveryClient, nil)
 
 			reconciler = &KonfluxReconciler{
 				Client:      fakeClient,
@@ -235,7 +235,7 @@ var _ = Describe("Konflux Controller - Cert-Manager Dependency", func() {
 				hasCertManager: false,
 				returnError:    true,
 			}
-			clusterInfo, _ := clusterinfo.DetectWithClient(mockDiscoveryClient)
+			clusterInfo, _ := clusterinfo.DetectWithClient(mockDiscoveryClient, nil)
 
 			reconciler = &KonfluxReconciler{
 				Client:      fakeClient,

--- a/operator/internal/controller/konflux/konflux_controller_test.go
+++ b/operator/internal/controller/konflux/konflux_controller_test.go
@@ -522,7 +522,7 @@ func createTestClusterInfo() *clusterinfo.Info {
 		resources:     map[string]*metav1.APIResourceList{},
 		serverVersion: &version.Info{GitVersion: "v1.30.0"},
 	}
-	info, _ := clusterinfo.DetectWithClient(mockClient)
+	info, _ := clusterinfo.DetectWithClient(mockClient, nil)
 	return info
 }
 

--- a/operator/internal/controller/ui/konfluxui_controller_test.go
+++ b/operator/internal/controller/ui/konfluxui_controller_test.go
@@ -706,13 +706,13 @@ var _ = Describe("KonfluxUI Controller", func() {
 					},
 				},
 				serverVersion: &version.Info{GitVersion: "v1.29.0"},
-			})
+			}, nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			defaultClusterInfo, err = clusterinfo.DetectWithClient(&mockDiscoveryClient{
 				resources:     map[string]*metav1.APIResourceList{},
 				serverVersion: &version.Info{GitVersion: "v1.29.0"},
-			})
+			}, nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("creating the KonfluxUI resource with ingress enabled")
@@ -1130,13 +1130,13 @@ var _ = Describe("KonfluxUI Controller", func() {
 					},
 				},
 				serverVersion: &version.Info{GitVersion: "v1.29.0"},
-			})
+			}, nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			defaultClusterInfo, err = clusterinfo.DetectWithClient(&mockDiscoveryClient{
 				resources:     map[string]*metav1.APIResourceList{},
 				serverVersion: &version.Info{GitVersion: "v1.29.0"},
-			})
+			}, nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("creating the KonfluxUI resource with ingress enabled")

--- a/operator/pkg/ingress/ingress_test.go
+++ b/operator/pkg/ingress/ingress_test.go
@@ -644,7 +644,7 @@ func createOpenShiftClusterInfo() *clusterinfo.Info {
 		serverVersion: &version.Info{GitVersion: "v1.29.0"},
 	}
 
-	info, _ := clusterinfo.DetectWithClient(mock)
+	info, _ := clusterinfo.DetectWithClient(mock, nil)
 	return info
 }
 
@@ -655,7 +655,7 @@ func createNonOpenShiftClusterInfo() *clusterinfo.Info {
 		serverVersion: &version.Info{GitVersion: "v1.29.0"},
 	}
 
-	info, _ := clusterinfo.DetectWithClient(mock)
+	info, _ := clusterinfo.DetectWithClient(mock, nil)
 	return info
 }
 


### PR DESCRIPTION
This commit adds the OpenShift version to the public info.

- Use the poller to fetch the OpenShift version
- Add tests for the OpenShift version
- Update existing tests